### PR TITLE
Function definitions with two parameters & Expression combinations as parameters

### DIFF
--- a/interpreter.cpp
+++ b/interpreter.cpp
@@ -171,6 +171,14 @@ double applyUnaryOperator(char operatorChar, double a) {
     }
 }
 
+double applyFunction(const std::string& func, const std::vector<double>& args) {
+    if (func == "pow") return std::pow(args[0], args[1]);
+    if (func == "abs") return std::abs(args[0]);
+    if (func == "max") return std::max(args[0], args[1]);
+    if (func == "min") return std::min(args[0], args[1]);
+    throw std::runtime_error("Unknown function");
+}
+
 double evaluatePostfix(std::queue<Token>& postfix) {
     std::stack<double> evalStack;
 
@@ -185,8 +193,7 @@ double evaluatePostfix(std::queue<Token>& postfix) {
                 if (evalStack.empty()) {
                     throw std::runtime_error("Incorrect syntax");
                 }
-                double a = evalStack.top();
-                evalStack.pop();
+                double a = evalStack.top(); evalStack.pop();
                 evalStack.push(applyUnaryOperator(token.op, a));
             } else {
                 if (evalStack.size() < 2) {
@@ -198,11 +205,27 @@ double evaluatePostfix(std::queue<Token>& postfix) {
                 evalStack.pop();
                 evalStack.push(applyOperator(token.op, a, b));
             }
+        } else if (token.type == FUNCTION) {
+            std::vector<double> args;
+            if (token.func == "abs") {
+                if (evalStack.empty()) {
+                    throw std::runtime_error("Incorrect syntax");
+                }
+                double a = evalStack.top(); evalStack.pop();
+                evalStack.push(applyFunction(token.func, {a}));
+            } else {
+                for (int i = 0; i < 2 && !evalStack.empty(); ++i) {
+                    args.insert(args.begin(), evalStack.top());
+                    evalStack.pop();
+                }
+                evalStack.push(applyFunction(token.func, args));
+            }
         }
     }
     if (evalStack.size() != 1) {
         throw std::runtime_error("Invalid expression");
     }
+
     return evalStack.top();
 }
 


### PR DESCRIPTION
### Description:
- Added support for unary operators.
- Implemented function definitions and function evaluation.

### Changes:
- Modified program to support unary operators:
  - Added struct constructor to initialize token with default values including isUnary flag.
  - Modified `tokenize()` and `infixToPostfix()` accordingly.
  - Implemented `applyUnaryOperator()` used in `evaluatePostfix()`.
  - Replaced `tokens.push_back` with `tokens.emplace_back` everywhere.
- Added `func` member variable to `Token` struct and modified constructor accordingly.
  - Implemented `isFunction()` function to recognize function tokens in `tokenize()` function.
  - Modified `infixToPostfix()` function to have according cases for function & comma tokens.
- Created `applyFunction()` function to evaluate functions with two parameters with the possibility of combining different expressions.
  - Modified `evaluatePostfix()` to use `applyFunction()`.

### How to Test:
1. Enter an arithmetic expression with unary operators (e.g., `-5 + 3`).
2. Verify that the correct result is displayed.
3. Enter an arithmetic expression with functions (e.g., `pow(2, 3)` or `max(5, 3)`).
4. Verify that the correct result is displayed.
5. Enter a combination of expressions with unary operators and functions.
6. Verify that the correct result is displayed.
7. Enter invalid expressions.
8. Verify that the correct error prompt is displayed.

### Screenshots:
1-2. 
![1](https://github.com/user-attachments/assets/d7189654-e28f-44e0-910d-668fac073ab7)
3-4.
![Screenshot 2024-07-17 133939](https://github.com/user-attachments/assets/848214e6-0495-44fe-a6e7-0d9323bf553b)
![Screenshot 2024-07-17 141457](https://github.com/user-attachments/assets/b7768b01-3153-409e-a476-f981e8536431)

5-6.
![Screenshot 2024-07-17 134014](https://github.com/user-attachments/assets/5e488b3e-0025-42fa-a35e-187605b374e5)
![3](https://github.com/user-attachments/assets/69c731e4-7251-4378-8085-e8a4afcbe3aa)
![Screenshot 2024-07-17 141440](https://github.com/user-attachments/assets/afaeb20c-c9ee-44b9-ab77-059c1c3bbf41)
6-7.
![4](https://github.com/user-attachments/assets/8ff88c23-3231-4233-938f-d73d82862bc3)
![5](https://github.com/user-attachments/assets/58392f9d-8a71-4826-abd6-f6ed55e0a98f)
![6](https://github.com/user-attachments/assets/9b8e8d66-24ef-422f-9278-b786ae1ed24f)